### PR TITLE
for #6: web extension artifacts to enable test pilot experiment

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -112,7 +112,12 @@ function blockTrackerRequests(requestDetails) {
     // Allow request if the origin has been added to allowedHosts
     if (currentOriginDisabled) {
       console.log("Protection disabled for this site; allowing request.");
-      chrome.tabs.sendMessage(requestTabID, {'origin-disabled': originTopHost});
+      chrome.tabs.sendMessage(requestTabID,
+          {
+            'origin-disabled': originTopHost,
+            'reason-given': reasons_given[requestTabID]
+          }
+      );
       return {};
     }
 

--- a/js/background.js
+++ b/js/background.js
@@ -10,11 +10,13 @@ var current_origin_disabled_index = -1;
 var current_active_origin;
 var blocked_requests = {};
 var total_exec_time = {};
+var reasons_given = {};
 
 
 function restartBlokForTab(tabID) {
   blocked_requests[tabID] = [];
   total_exec_time[tabID] = 0;
+  reasons_given[tabID] = null;
 }
 
 
@@ -79,7 +81,7 @@ var getAllowedHosts = new Promise(function(resolve, reject) {
     if (Object.keys(item).length === 0) {
       allowedHosts = [];
     } else {
-      allowedHosts = item;
+      allowedHosts = item.allowedHosts;
     }
     resolve(allowedHosts);
   });
@@ -182,7 +184,8 @@ chrome.runtime.onMessage.addListener(function (message) {
     testpilotPingChannel.postMessage({
       originDomain: current_active_origin,
       trackerDomains: blocked_requests[current_active_tab_id],
-      reason: message.disable-reason
+      reason: message['disable-reason']
     });
+    reasons_given[current_active_tab_id] = message['disable-reason'];
   }
 });

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -5,7 +5,11 @@ chrome.runtime.onMessage.addListener(function (runtimeMessage) {
     document.querySelector('#title-disabled').className = 'title';
     document.querySelector('#title-origin').innerHTML = runtimeMessage['origin-disabled'];
     document.querySelector('#disable').className = 'hide';
-    document.querySelector('#disable-reasons').className = '';
+    if (runtimeMessage.hasOwnProperty('reason-given') && runtimeMessage['reason-given'] != null) {
+      document.querySelector('#disable-reason-thankyou').className = '';
+    } else {
+      document.querySelector('#disable-reasons').className = '';
+    }
   } else {
     blockedCount = runtimeMessage.blocked_requests.length;
     document.querySelector('#title-block-count').innerHTML = blockedCount;
@@ -28,7 +32,7 @@ for (closeBtn of document.querySelectorAll('.close-btn')) {
 
 for (reasonBtn of document.querySelectorAll('.reason')) {
   reasonBtn.addEventListener('click', function (event) {
-    chrome.runtime.sendMessage({"disable-reason": event.target.value});
+    chrome.runtime.sendMessage({"disable-reason": event.target.text});
     document.querySelector('#disable-reasons').className = 'hide';
     document.querySelector('#disable-reason-thankyou').className = '';
   });

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -29,5 +29,7 @@ for (closeBtn of document.querySelectorAll('.close-btn')) {
 for (reasonBtn of document.querySelectorAll('.reason')) {
   reasonBtn.addEventListener('click', function (event) {
     chrome.runtime.sendMessage({"disable-reason": event.target.value});
+    document.querySelector('#disable-reasons').className = 'hide';
+    document.querySelector('#disable-reason-thankyou').className = '';
   });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
 
   "applications": {
     "gecko": {
-      "id": "lcrouch@mozilla.org",
+      "id": "blok@mozilla.org",
       "strict_min_version": "45.0"
     }
   },

--- a/toolbar.html
+++ b/toolbar.html
@@ -32,6 +32,10 @@
           <a id="disable-reason-allow" class="tiny button reason">Other</a>
           <a class="tiny secondary hollow button close-btn"><i class="fi-x"></i></a>
         </div>
+        <div id="disable-reason-thankyou" class="hide">
+          Thank you for your feedback.
+          <a class="tiny secondary hollow button close-btn"><i class="fi-x"></i></a>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Recording testing steps here, as they are extensive, and I'm moving onto more issues.

1. Clone testpilot repo locally
  * For now, need to clone the [lmorchard/433-webextension-telemetry-2 fork/branch](https://github.com/lmorchard/testpilot/tree/433-webextension-telemetry-2)
2. Follow the [testpilot quickstart](https://github.com/mozilla/testpilot#quickstart) to set up http://testpilot.dev:8000
3. Open Firefox 48+ to http://testpilot.dev:8000 and click "Install Test Pilot"
4. Go to http://testpilot.dev:8000/admin/experiments/experiment/add/ (user: admin, pass: admin)
5. Create an experiment for blok, the only specific values you need are:
  * xpi url: https://github.com/mozilla/blok/raw/web-ext-artifacts/web-ext-artifacts/blok-0.1.xpi
  * addon id: blok@mozilla.org
6. Go to http://testpilot.dev:8000/experiments
  * Should see the blok experiment
7. Click the experiment, and click "Enable"

To verify the broadcast channel is working:

1. Open the browser toolbox debugger
2. Place a breakpoint at `lib/webextension-channels.js:144` (`Metrics.onExperimentPing`)
3. In the browser, visit a site on which Blok blocks trackers (e.g., economist.com)
4. Click "Disable blok"
  * When the page reloads, it should ask why you disabled blok
6. Click "The page was broken"
7. You should see the browser toolbox debugger paused at the `Metrics.onExperimentPing` line - this means the disable reason message was successfully sent via the broadcast channel to the test pilot add-on to send a telemetry ping.

The pixels of victory:

![blok-testpilot-telemetry-debugger](https://cloud.githubusercontent.com/assets/71928/16656256/9ec49cc4-4423-11e6-9eb1-344ffb6a6d9b.png)
