### PR TITLE
Add ESLint and fix a few formatting errors

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+js/foundation.min.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
+js/*.bundle.js
 js/foundation.min.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 js/*.bundle.js
-js/foundation.min.js
+js/*.min.js

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,12 +8,17 @@ extends:
 
 globals:
   browser: false
+  BroadcastChannel: false
 
 root: true
 
 rules:
-  eol-last: 2
-  eqeqeq: 1
+  eol-last: 1
+  eqeqeq: [2, smart]
   indent: [2, 2]
   no-console: 0
+  no-trailing-spaces: 1
+  no-unused-vars: 1 # TODO: Change to 2
+  one-var: [2, never]
   quotes: [2, single]
+  semi: [2, always]

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,18 @@
+env:
+  browser: true
+  es6: true
+  node: true
+
+extends:
+  - eslint:recommended
+
+globals:
+  browser: false
+
+root: true
+
+rules:
+  eqeqeq: 1
+  indent: [2, 2]
+  no-console: 0
+  quotes: [2, single]

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,6 +12,7 @@ globals:
 root: true
 
 rules:
+  eol-last: 2
   eqeqeq: 1
   indent: [2, 2]
   no-console: 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.bundle.js
+*.log

--- a/js/background.js
+++ b/js/background.js
@@ -55,14 +55,14 @@ function blockTrackerRequests(blocklist, allowedHosts, entityList) {
     }
 
     currentOriginDisabled = current_origin_disabled_index > -1;
-    firefoxOrigin = (typeof originTopHost !== "undefined" && originTopHost.includes('moz-nullprincipal'));
+    firefoxOrigin = (typeof originTopHost !== 'undefined' && originTopHost.includes('moz-nullprincipal'));
     newOrigin = originTopHost == '';
 
 
     // Allow request originating from Firefox and/or new tab/window origins
     if (firefoxOrigin || newOrigin) {
-        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-        return {};
+      total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
+      return {};
     }
 
     requestTopHost = canonicalizeHost(new URL(requestDetails.url).host);
@@ -77,8 +77,8 @@ function blockTrackerRequests(blocklist, allowedHosts, entityList) {
 
     // Allow requests to 3rd-party domains NOT in the block-list
     if (!requestHostInBlocklist) {
-        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-        return {};
+      total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
+      return {};
     }
 
     requestIsThirdParty = requestTopHost != originTopHost;
@@ -128,13 +128,13 @@ function blockTrackerRequests(blocklist, allowedHosts, entityList) {
 
       // Allow request if the origin has been added to allowedHosts
       if (currentOriginDisabled) {
-        log("Protection disabled for this site; allowing request.");
+        log('Protection disabled for this site; allowing request.');
         browser.tabs.sendMessage(requestTabID,
-            {
-              'origin-disabled': originTopHost,
-              'reason-given': reasons_given[requestTabID],
-              'allowed_entities': allowed_entities[requestTabID]
-            }
+          {
+            'origin-disabled': originTopHost,
+            'reason-given': reasons_given[requestTabID],
+            'allowed_entities': allowed_entities[requestTabID]
+          }
         );
         allowed_requests[requestTabID].push(requestTopHost);
         if (allowed_entities[requestTabID].indexOf(requestEntityName) === -1) {
@@ -158,8 +158,8 @@ function blockTrackerRequests(blocklist, allowedHosts, entityList) {
     }
 
   // none of the above checks matched, so default to allowing the request
-  total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-  return {}
+    total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
+    return {}
 
   }
 
@@ -169,8 +169,8 @@ function blockTrackerRequests(blocklist, allowedHosts, entityList) {
 function startListeners({blocklist, allowedHosts, entityList}) {
   browser.webRequest.onBeforeRequest.addListener(
       blockTrackerRequests(blocklist, allowedHosts, entityList),
-      {urls:["*://*/*"]},
-      ["blocking"]
+      {urls:['*://*/*']},
+      ['blocking']
   );
 
   browser.tabs.onActivated.addListener(function(activeInfo) {
@@ -178,25 +178,25 @@ function startListeners({blocklist, allowedHosts, entityList}) {
   });
 
   browser.tabs.onUpdated.addListener(function(tabID, changeInfo) {
-    if (changeInfo.status == "loading") {
+    if (changeInfo.status == 'loading') {
       restartBlokForTab(tabID);
-    } else if (changeInfo.status == "complete") {
-      let actionPerformed = (current_origin_disabled_index === -1) ? "Blocked " : "Detected ";
+    } else if (changeInfo.status == 'complete') {
+      let actionPerformed = (current_origin_disabled_index === -1) ? 'Blocked ' : 'Detected ';
       let actionRequests = (current_origin_disabled_index === -1) ? blocked_requests[tabID] : allowed_requests[tabID];
       let actionEntities = (current_origin_disabled_index === -1) ? blocked_entities[tabID] : allowed_entities[tabID];
-      log("blocked " + actionRequests.length + " requests: " + actionRequests);
-      log("from " + actionEntities.length + " entities: " + actionEntities);
-      log("total_exec_time: " + total_exec_time[tabID]);
+      log('blocked ' + actionRequests.length + ' requests: ' + actionRequests);
+      log('from ' + actionEntities.length + ' entities: ' + actionEntities);
+      log('total_exec_time: ' + total_exec_time[tabID]);
     }
   });
 
   browser.runtime.onMessage.addListener(function (message) {
-    if (message == "disable") {
+    if (message == 'disable') {
       allowedHosts.push(current_active_origin);
       browser.storage.local.set({allowedHosts: allowedHosts});
       browser.tabs.reload(current_active_tab_id);
     }
-    if (message == "re-enable") {
+    if (message == 're-enable') {
       allowedHosts.splice(current_origin_disabled_index, 1);
       browser.storage.local.set({allowedHosts: allowedHosts});
       browser.tabs.reload(current_active_tab_id);
@@ -207,12 +207,12 @@ function startListeners({blocklist, allowedHosts, entityList}) {
         trackerDomains: blocked_requests[current_active_tab_id],
         feedback: message.feedback
       };
-      log("telemetry ping payload: " + JSON.stringify(testPilotPingMessage));
+      log('telemetry ping payload: ' + JSON.stringify(testPilotPingMessage));
       testpilotPingChannel.postMessage(testPilotPingMessage);
-      log("mainFrameOriginTopHosts[current_active_tab_id]: " + mainFrameOriginTopHosts[current_active_tab_id]);
+      log('mainFrameOriginTopHosts[current_active_tab_id]: ' + mainFrameOriginTopHosts[current_active_tab_id]);
       browser.tabs.sendMessage(current_active_tab_id, {
-        "feedback": message.feedback,
-        "origin": mainFrameOriginTopHosts[current_active_tab_id]
+        'feedback': message.feedback,
+        'origin': mainFrameOriginTopHosts[current_active_tab_id]
       });
     }
     if (message.hasOwnProperty('breakage')) {
@@ -222,7 +222,7 @@ function startListeners({blocklist, allowedHosts, entityList}) {
         breakage: message.breakage,
         notes: message.notes
       };
-      log("telemetry ping payload: " + JSON.stringify(testPilotPingMessage));
+      log('telemetry ping payload: ' + JSON.stringify(testPilotPingMessage));
       testpilotPingChannel.postMessage(testPilotPingMessage);
       browser.tabs.sendMessage(current_active_tab_id, message);
     }

--- a/js/canonicalize.js
+++ b/js/canonicalize.js
@@ -25,11 +25,10 @@ function canonicalizeHost(host) {
   // The client should handle any legal IP-address encoding,
   // including octal, hex, and TODO: fewer than four components
   var base = 10;
-  var isIP4Decimal, isIP4Hex, isIP4Octal;
+  var isIP4Decimal = canonicalizedHost.match(ip4DecimalPattern) != null;
+  var isIP4Hex = canonicalizedHost.match(ip4HexPattern) != null;
+  var isIP4Octal = canonicalizedHost.match(ip4OctalPattern) != null;
 
-  isIP4Decimal = canonicalizedHost.match(ip4DecimalPattern) != null;
-  isIP4Hex = canonicalizedHost.match(ip4HexPattern) != null;
-  isIP4Octal = canonicalizedHost.match(ip4OctalPattern) != null;
   if (isIP4Hex || isIP4Octal) {
     if (isIP4Hex) {
       base = 16;
@@ -60,4 +59,4 @@ module.exports = {
   allHosts,
   canonicalizeHost,
   trim
-}
+};

--- a/js/contentscript.js
+++ b/js/contentscript.js
@@ -1,4 +1,5 @@
-var toolbarFrame, feedbackModalOverlay;
+var feedbackModalOverlay;
+var toolbarFrame;
 
 toolbarFrame = document.getElementById('blok-toolbar-iframe');
 feedbackModalOverlay = document.getElementById('blok-feedback-modal-overlay');
@@ -33,16 +34,16 @@ browser.runtime.onMessage.addListener(function (message) {
   }
 
   // page-problem message should show modal for feedback
-  if (message.feedback && message.feedback == 'page-problem') {
+  if (message.feedback && message.feedback === 'page-problem') {
     feedbackModalOverlay.setAttribute('class', 'blok-feedback-modal-overlay');
     document.body.appendChild(feedbackModalOverlay);
     console.log('message.origin: ' + message.origin);
     feedbackModalOverlay.querySelector('#blok-feedback-iframe').contentDocument.querySelector('#feedback-title-site-name').textContent = message.origin;
-  } else if (message.feedback && message.feedback == 'page-works') {
-    feedbackModalOverlay.remove()
+  } else if (message.feedback && message.feedback === 'page-works') {
+    feedbackModalOverlay.remove();
   }
 
-  if (message == 'close-feedback') {
-    feedbackModalOverlay.remove()
+  if (message === 'close-feedback') {
+    feedbackModalOverlay.remove();
   }
 });

--- a/js/contentscript.js
+++ b/js/contentscript.js
@@ -6,43 +6,43 @@ feedbackModalOverlay = document.getElementById('blok-feedback-modal-overlay');
 browser.runtime.onMessage.addListener(function (message) {
   // Any message indicates Blok has something to show
   if (!toolbarFrame) {
-    var toolbarSpacer = document.createElement("div");
-    toolbarSpacer.setAttribute("id", "blok-toolbar-spacer");
-    toolbarSpacer.setAttribute("class", "blok-toolbar-spacer");
-    var bodyEl = document.getElementsByTagName("body")[0];
+    var toolbarSpacer = document.createElement('div');
+    toolbarSpacer.setAttribute('id', 'blok-toolbar-spacer');
+    toolbarSpacer.setAttribute('class', 'blok-toolbar-spacer');
+    var bodyEl = document.getElementsByTagName('body')[0];
     bodyEl.insertBefore(toolbarSpacer, bodyEl.firstChild);
 
-    toolbarFrame = document.createElement("iframe");
-    toolbarFrame.setAttribute("id", "blok-toolbar-iframe");
-    toolbarFrame.setAttribute("class", "blok-toolbar-iframe");
-    toolbarFrame.setAttribute("src", browser.runtime.getURL('toolbar.html'));
+    toolbarFrame = document.createElement('iframe');
+    toolbarFrame.setAttribute('id', 'blok-toolbar-iframe');
+    toolbarFrame.setAttribute('class', 'blok-toolbar-iframe');
+    toolbarFrame.setAttribute('src', browser.runtime.getURL('toolbar.html'));
     document.body.appendChild(toolbarFrame);
   }
 
   if (!feedbackModalOverlay) {
-    feedbackModalOverlay = document.createElement("div");
-    feedbackModalOverlay.setAttribute("class", "blok-feedback-modal-overlay blok-hide");
+    feedbackModalOverlay = document.createElement('div');
+    feedbackModalOverlay.setAttribute('class', 'blok-feedback-modal-overlay blok-hide');
 
-    let feedbackFrame = document.createElement("iframe");
-    feedbackFrame.setAttribute("id", "blok-feedback-iframe");
-    feedbackFrame.setAttribute("class", "blok-feedback-iframe");
-    feedbackFrame.setAttribute("src", browser.runtime.getURL('feedback.html'));
+    let feedbackFrame = document.createElement('iframe');
+    feedbackFrame.setAttribute('id', 'blok-feedback-iframe');
+    feedbackFrame.setAttribute('class', 'blok-feedback-iframe');
+    feedbackFrame.setAttribute('src', browser.runtime.getURL('feedback.html'));
 
     feedbackModalOverlay.appendChild(feedbackFrame);
     document.body.appendChild(feedbackModalOverlay);
   }
 
   // page-problem message should show modal for feedback
-  if (message.feedback && message.feedback == "page-problem") {
-    feedbackModalOverlay.setAttribute("class", "blok-feedback-modal-overlay");
+  if (message.feedback && message.feedback == 'page-problem') {
+    feedbackModalOverlay.setAttribute('class', 'blok-feedback-modal-overlay');
     document.body.appendChild(feedbackModalOverlay);
-    console.log("message.origin: " + message.origin);
+    console.log('message.origin: ' + message.origin);
     feedbackModalOverlay.querySelector('#blok-feedback-iframe').contentDocument.querySelector('#feedback-title-site-name').textContent = message.origin;
-  } else if (message.feedback && message.feedback == "page-works") {
+  } else if (message.feedback && message.feedback == 'page-works') {
     feedbackModalOverlay.remove()
   }
 
-  if (message == "close-feedback") {
+  if (message == 'close-feedback') {
     feedbackModalOverlay.remove()
   }
 });

--- a/js/lists.js
+++ b/js/lists.js
@@ -20,8 +20,8 @@ function loadJSON(url) {
     var xhr = new XMLHttpRequest();
     xhr.open('get', url, true);
     xhr.responseType = 'json';
-    xhr.addEventListener("load", () => resolve(xhr));
-    xhr.addEventListener("error", () => reject(xhr));
+    xhr.addEventListener('load', () => resolve(xhr));
+    xhr.addEventListener('error', () => reject(xhr));
     xhr.send();
   });
 }
@@ -70,7 +70,7 @@ function processBlockListJSON(data) {
 
 
 function getAllowedHostsList() {
-  return browser.storage.local.get("allowedHosts").then((item) => {
+  return browser.storage.local.get('allowedHosts').then((item) => {
     if (item.allowedHosts) {
       return item.allowedHosts;
     }

--- a/js/lists.js
+++ b/js/lists.js
@@ -42,17 +42,17 @@ function processBlockListJSON(data) {
   // blocklist["doubleclick.net"] = http://www.google.com
   // blocklist["google-analytics.com"] = http://www.google.com
   // etc.
-  for (category_name in data.categories) {
+  for (let category_name in data.categories) {
     var category = data.categories[category_name];
     var entity_count = category.length;
 
     for (var i = 0; i < entity_count; i++) {
       var entity = category[i];
 
-      for (entity_name in entity) {
+      for (let entity_name in entity) {
         var urls = entity[entity_name];
 
-        for (main_domain in urls) {
+        for (let main_domain in urls) {
           blocklist[main_domain] = [];
           var domains = urls[main_domain];
           var domains_count = domains.length;
@@ -81,4 +81,4 @@ function getAllowedHostsList() {
 
 module.exports = {
   loadLists
-}
+};

--- a/js/log.js
+++ b/js/log.js
@@ -1,4 +1,4 @@
-if (process.env.MODE === "production") {
+if (process.env.MODE === 'production') {
   exports.log = function noop(){};
 } else {
   exports.log = console.log.bind(console);

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -1,5 +1,6 @@
 browser.runtime.onMessage.addListener(function (runtimeMessage) {
-  var blockedEntitiesCount, allowedEntitiesCount;
+  var allowedEntitiesCount;
+  var blockedEntitiesCount;
   if (runtimeMessage.hasOwnProperty('origin-disabled')) {
     allowedEntitiesCount = runtimeMessage.allowed_entities.length;
 

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -23,17 +23,17 @@ browser.runtime.onMessage.addListener(function (runtimeMessage) {
 });
 
 document.querySelector('#disable-link').addEventListener('click', function () {
-  browser.runtime.sendMessage("disable");
+  browser.runtime.sendMessage('disable');
 });
 
 document.querySelector('#re-enable-link').addEventListener('click', function () {
-  browser.runtime.sendMessage("re-enable");
+  browser.runtime.sendMessage('re-enable');
 });
 
 for (let feedbackBtn of document.querySelectorAll('.feedback-btn')) {
   feedbackBtn.addEventListener('click', function (event) {
     var feedback = event.target.dataset.feedback;
-    browser.runtime.sendMessage({"feedback": feedback});
+    browser.runtime.sendMessage({'feedback': feedback});
     for (let feedbackDiv of document.querySelectorAll('.feedback')) {
       feedbackDiv.className = 'hide';
     }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "test": "tests"
   },
   "scripts": {
-    "bundle": "browserify -d -t envify js/background.js > js/background.bundle.js",
     "build": "npm test && MODE=production npm run bundle && web-ext build",
     "build-dev": "npm test && MODE=dev npm run bundle && web-ext build",
+    "bundle": "browserify -d -t envify js/background.js > js/background.bundle.js",
     "coverage": "nyc npm test",
     "firefox": "npm run bundle && web-ext run",
     "lint": "eslint .",
+    "pretest": "npm run lint",
     "test": "tape tests/**/*.js | faucet",
     "watch": "npm-watch"
   },
@@ -33,6 +34,7 @@
   },
   "homepage": "https://github.com/mozilla/blok#readme",
   "devDependencies": {
+    "addons-linter": "0.14.1",
     "browserify": "13.0.1",
     "envify": "3.4.1",
     "eslint": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-dev": "npm test && MODE=dev npm run bundle && web-ext build",
     "coverage": "nyc npm test",
     "firefox": "npm run bundle && web-ext run",
+    "lint": "eslint .",
     "test": "tape tests/**/*.js | faucet",
     "watch": "npm-watch"
   },
@@ -34,6 +35,7 @@
   "devDependencies": {
     "browserify": "13.0.1",
     "envify": "3.4.1",
+    "eslint": "3.1.1",
     "faucet": "0.0.1",
     "npm-watch": "0.1.5",
     "nyc": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "faucet": "0.0.1",
     "npm-watch": "0.1.5",
     "nyc": "7.0.0",
-    "tape": "4.6.0"
+    "tape": "4.6.0",
+    "web-ext": "1.3.0"
   },
   "watch": {
     "bundle": {


### PR DESCRIPTION
Currently `✖ 2 problems (0 errors, 2 warnings)`.

~~Once we land this and get the ESLint hook passing, we may want to add a npm script `pretest` hook that runs `"pretest": "npm run lint"` so ESLint will run automatically every time you run `$ npm test` or the build runs on Travis-CI.~~ Done.

### How to:

```sh
$ npm run lint

> blok@1.0.0 lint /Users/pdehaan/dev/github/mozilla/blok
> eslint .


/Users/pdehaan/dev/github/mozilla/blok/js/background.js
  185:11  warning  'actionPerformed' is defined but never used  no-unused-vars

/Users/pdehaan/dev/github/mozilla/blok/js/canonicalize.js
  28:7  warning  'isIP4Decimal' is defined but never used  no-unused-vars

✖ 2 problems (0 errors, 2 warnings)
```

r? @groovecoder 