### PR TITLE
Switch from ESLint to Standard for code formatting

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,219 +1,214 @@
-var {allHosts, canonicalizeHost} = require('./canonicalize');
-const {loadLists} = require('./lists');
-const {log} = require('./log');
+var {allHosts, canonicalizeHost} = require('./canonicalize')
+const {loadLists} = require('./lists')
+const {log} = require('./log')
 
-var TESTPILOT_TELEMETRY_CHANNEL = 'testpilot-telemetry';
-var testpilotPingChannel = new BroadcastChannel(TESTPILOT_TELEMETRY_CHANNEL);
+var TESTPILOT_TELEMETRY_CHANNEL = 'testpilot-telemetry'
+var testpilotPingChannel = new BroadcastChannel(TESTPILOT_TELEMETRY_CHANNEL)
 
 // HACK: Start with active tab id = 1 when browser starts
-var current_active_tab_id = 1;
-var current_origin_disabled_index = -1;
-var current_active_origin;
-var blocked_requests = {};
-var blocked_entities = {};
-var allowed_requests = {};
-var allowed_entities = {};
-var total_exec_time = {};
-var reasons_given = {};
-var mainFrameOriginTopHosts = {};
+var current_active_tab_id = 1
+var current_origin_disabled_index = -1
+var current_active_origin
+var blocked_requests = {}
+var blocked_entities = {}
+var allowed_requests = {}
+var allowed_entities = {}
+var total_exec_time = {}
+var reasons_given = {}
+var mainFrameOriginTopHosts = {}
 
-
-function restartBlokForTab(tabID) {
-  blocked_requests[tabID] = [];
-  blocked_entities[tabID] = [];
-  allowed_requests[tabID] = [];
-  allowed_entities[tabID] = [];
-  total_exec_time[tabID] = 0;
-  reasons_given[tabID] = null;
-  mainFrameOriginTopHosts[tabID] = null;
+function restartBlokForTab (tabID) {
+  blocked_requests[tabID] = []
+  blocked_entities[tabID] = []
+  allowed_requests[tabID] = []
+  allowed_entities[tabID] = []
+  total_exec_time[tabID] = 0
+  reasons_given[tabID] = null
+  mainFrameOriginTopHosts[tabID] = null
 }
 
-
-function blockTrackerRequests(blocklist, allowedHosts, entityList) {
-  return function filterRequest(requestDetails) {
-    var blockTrackerRequestsStart = Date.now();
-    var requestTabID = requestDetails.tabId;
-    var originTopHost, requestTopHost;
+function blockTrackerRequests (blocklist, allowedHosts, entityList) {
+  return function filterRequest (requestDetails) {
+    var blockTrackerRequestsStart = Date.now()
+    var requestTabID = requestDetails.tabId
+    var originTopHost
+    var requestTopHost
 
     // Start with all origin flags false
-    var currentOriginDisabled = false;
-    var firefoxOrigin = false;
-    var newOrigin = false;
+    var currentOriginDisabled = false
+    var firefoxOrigin = false
+    var newOrigin = false
 
-    var requestEntityName;
-    var requestHostInBlocklist = false;
-    var requestIsThirdParty = false;
-    var requestHostMatchesMainFrame = false;
+    var requestEntityName
+    var requestHostInBlocklist = false
+    var requestIsThirdParty = false
+    var requestHostMatchesMainFrame = false
 
     // Determine all origin flags
-    originTopHost = canonicalizeHost(new URL(requestDetails.originUrl).host);
-    current_active_origin = originTopHost;
-    current_origin_disabled_index = allowedHosts.indexOf(current_active_origin);
-    
-    if (requestDetails.frameId == 0) {
-      mainFrameOriginTopHosts[requestTabID] = originTopHost;
+    originTopHost = canonicalizeHost(new URL(requestDetails.originUrl).host)
+    current_active_origin = originTopHost
+    current_origin_disabled_index = allowedHosts.indexOf(current_active_origin)
+
+    if (requestDetails.frameId === 0) {
+      mainFrameOriginTopHosts[requestTabID] = originTopHost
     }
 
-    currentOriginDisabled = current_origin_disabled_index > -1;
-    firefoxOrigin = (typeof originTopHost !== "undefined" && originTopHost.includes('moz-nullprincipal'));
-    newOrigin = originTopHost == '';
-
+    currentOriginDisabled = current_origin_disabled_index > -1
+    firefoxOrigin = (typeof originTopHost !== 'undefined' && originTopHost.includes('moz-nullprincipal'))
+    newOrigin = originTopHost === ''
 
     // Allow request originating from Firefox and/or new tab/window origins
     if (firefoxOrigin || newOrigin) {
-        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-        return {};
+      total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart
+      return {}
     }
 
-    requestTopHost = canonicalizeHost(new URL(requestDetails.url).host);
+    requestTopHost = canonicalizeHost(new URL(requestDetails.url).host)
     // check if any host from lowest-level to top-level is in the blocklist
-    var allRequestHosts = allHosts(requestTopHost);
+    var allRequestHosts = allHosts(requestTopHost)
     for (let requestHost of allRequestHosts) {
-      requestHostInBlocklist = blocklist.hasOwnProperty(requestHost);
+      requestHostInBlocklist = blocklist.hasOwnProperty(requestHost)
       if (requestHostInBlocklist) {
-        break;
+        break
       }
     }
 
     // Allow requests to 3rd-party domains NOT in the block-list
     if (!requestHostInBlocklist) {
-        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-        return {};
+      total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart
+      return {}
     }
 
-    requestIsThirdParty = requestTopHost != originTopHost;
+    requestIsThirdParty = requestTopHost !== originTopHost
 
     if (requestIsThirdParty) {
       // Allow all requests to the main frame origin domain from child frames' pages
-      requestHostMatchesMainFrame = (requestDetails.frameId > 0 && requestTopHost == mainFrameOriginTopHosts[requestTabID]);
+      requestHostMatchesMainFrame = (requestDetails.frameId > 0 && requestTopHost === mainFrameOriginTopHosts[requestTabID])
       if (requestHostMatchesMainFrame) {
-        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-        return {};
+        total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart
+        return {}
       }
-      log(`requestTopHost: ${requestTopHost} does not match originTopHost: ${originTopHost}...`);
+      log(`requestTopHost: ${requestTopHost} does not match originTopHost: ${originTopHost}...`)
 
       for (entityName in entityList) {
-        var entity = entityList[entityName];
-        var requestIsEntityResource = false;
-        var originIsEntityProperty = false;
-        var mainFrameOriginIsEntityProperty = false;
+        var entity = entityList[entityName]
+        var requestIsEntityResource = false
+        var originIsEntityProperty = false
+        var mainFrameOriginIsEntityProperty = false
 
         for (let requestHost of allHosts(requestTopHost)) {
-          requestIsEntityResource = entity.resources.indexOf(requestHost) > -1;
+          requestIsEntityResource = entity.resources.indexOf(requestHost) > -1
           if (requestIsEntityResource) {
-            requestEntityName = entityName;
-            break;
+            requestEntityName = entityName
+            break
           }
         }
         for (let originHost of allHosts(originTopHost)) {
-          originIsEntityProperty = entity.properties.indexOf(originHost) > -1;
+          originIsEntityProperty = entity.properties.indexOf(originHost) > -1
           if (originIsEntityProperty) {
-            break;
+            break
           }
         }
 
         for (let mainFrameOriginHost of allHosts(mainFrameOriginTopHosts[requestTabID])) {
-          mainFrameOriginIsEntityProperty = entity.properties.indexOf(mainFrameOriginHost) > -1;
+          mainFrameOriginIsEntityProperty = entity.properties.indexOf(mainFrameOriginHost) > -1
           if (mainFrameOriginIsEntityProperty) {
-            break;
+            break
           }
         }
 
         if ((originIsEntityProperty || mainFrameOriginIsEntityProperty) && requestIsEntityResource) {
-          log(`originTopHost ${originTopHost} and resource requestTopHost ${requestTopHost} belong to the same entity: ${entityName}; allowing request`);
-          total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-          return {};
+          log(`originTopHost ${originTopHost} and resource requestTopHost ${requestTopHost} belong to the same entity: ${entityName}; allowing request`)
+          total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart
+          return {}
         }
       }
 
       // Allow request if the origin has been added to allowedHosts
       if (currentOriginDisabled) {
-        log("Protection disabled for this site; allowing request.");
+        log('Protection disabled for this site; allowing request.')
         browser.tabs.sendMessage(requestTabID,
-            {
-              'origin-disabled': originTopHost,
-              'reason-given': reasons_given[requestTabID],
-              'allowed_entities': allowed_entities[requestTabID]
-            }
-        );
-        allowed_requests[requestTabID].push(requestTopHost);
+          {
+            'origin-disabled': originTopHost,
+            'reason-given': reasons_given[requestTabID],
+            'allowed_entities': allowed_entities[requestTabID]
+          }
+        )
+        allowed_requests[requestTabID].push(requestTopHost)
         if (allowed_entities[requestTabID].indexOf(requestEntityName) === -1) {
-          allowed_entities[requestTabID].push(requestEntityName);
+          allowed_entities[requestTabID].push(requestEntityName)
         }
-        return {};
+        return {}
       }
 
-      blocked_requests[requestTabID].push(requestTopHost);
+      blocked_requests[requestTabID].push(requestTopHost)
       if (blocked_entities[requestTabID].indexOf(requestEntityName) === -1) {
-        blocked_entities[requestTabID].push(requestEntityName);
+        blocked_entities[requestTabID].push(requestEntityName)
       }
 
-      total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
+      total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart
       browser.tabs.sendMessage(requestTabID, {
         blocked_requests: blocked_requests[requestTabID],
         blocked_entities: blocked_entities[requestTabID]
-      });
+      })
 
-      return {cancel: true};
+      return {cancel: true}
     }
 
-  // none of the above checks matched, so default to allowing the request
-  total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart;
-  return {}
-
+    // none of the above checks matched, so default to allowing the request
+    total_exec_time[requestTabID] += Date.now() - blockTrackerRequestsStart
+    return {}
   }
-
 }
 
-
-function startListeners({blocklist, allowedHosts, entityList}) {
+function startListeners ({blocklist, allowedHosts, entityList}) {
   browser.webRequest.onBeforeRequest.addListener(
-      blockTrackerRequests(blocklist, allowedHosts, entityList),
-      {urls:["*://*/*"]},
-      ["blocking"]
-  );
+    blockTrackerRequests(blocklist, allowedHosts, entityList),
+    {urls: ['*://*/*']},
+    ['blocking']
+  )
 
-  browser.tabs.onActivated.addListener(function(activeInfo) {
-    current_active_tab_id = activeInfo.tabId;
-  });
+  browser.tabs.onActivated.addListener(function (activeInfo) {
+    current_active_tab_id = activeInfo.tabId
+  })
 
-  browser.tabs.onUpdated.addListener(function(tabID, changeInfo) {
-    if (changeInfo.status == "loading") {
-      restartBlokForTab(tabID);
-    } else if (changeInfo.status == "complete") {
-      let actionPerformed = (current_origin_disabled_index === -1) ? "Blocked " : "Detected ";
-      let actionRequests = (current_origin_disabled_index === -1) ? blocked_requests[tabID] : allowed_requests[tabID];
-      let actionEntities = (current_origin_disabled_index === -1) ? blocked_entities[tabID] : allowed_entities[tabID];
-      log("blocked " + actionRequests.length + " requests: " + actionRequests);
-      log("from " + actionEntities.length + " entities: " + actionEntities);
-      log("total_exec_time: " + total_exec_time[tabID]);
+  browser.tabs.onUpdated.addListener(function (tabID, changeInfo) {
+    if (changeInfo.status === 'loading') {
+      restartBlokForTab(tabID)
+    } else if (changeInfo.status === 'complete') {
+      let actionPerformed = (current_origin_disabled_index === -1) ? 'Blocked ' : 'Detected '
+      let actionRequests = (current_origin_disabled_index === -1) ? blocked_requests[tabID] : allowed_requests[tabID]
+      let actionEntities = (current_origin_disabled_index === -1) ? blocked_entities[tabID] : allowed_entities[tabID]
+      log('blocked ' + actionRequests.length + ' requests: ' + actionRequests)
+      log('from ' + actionEntities.length + ' entities: ' + actionEntities)
+      log('total_exec_time: ' + total_exec_time[tabID])
     }
-  });
+  })
 
   browser.runtime.onMessage.addListener(function (message) {
-    if (message == "disable") {
-      allowedHosts.push(current_active_origin);
-      browser.storage.local.set({allowedHosts: allowedHosts});
-      browser.tabs.reload(current_active_tab_id);
+    if (message === 'disable') {
+      allowedHosts.push(current_active_origin)
+      browser.storage.local.set({allowedHosts: allowedHosts})
+      browser.tabs.reload(current_active_tab_id)
     }
-    if (message == "re-enable") {
-      allowedHosts.splice(current_origin_disabled_index, 1);
-      browser.storage.local.set({allowedHosts: allowedHosts});
-      browser.tabs.reload(current_active_tab_id);
+    if (message === 're-enable') {
+      allowedHosts.splice(current_origin_disabled_index, 1)
+      browser.storage.local.set({allowedHosts: allowedHosts})
+      browser.tabs.reload(current_active_tab_id)
     }
     if (message.hasOwnProperty('feedback')) {
       let testPilotPingMessage = {
         originDomain: current_active_origin,
         trackerDomains: blocked_requests[current_active_tab_id],
         feedback: message.feedback
-      };
-      log("telemetry ping payload: " + JSON.stringify(testPilotPingMessage));
-      testpilotPingChannel.postMessage(testPilotPingMessage);
-      log("mainFrameOriginTopHosts[current_active_tab_id]: " + mainFrameOriginTopHosts[current_active_tab_id]);
+      }
+      log('telemetry ping payload: ' + JSON.stringify(testPilotPingMessage))
+      testpilotPingChannel.postMessage(testPilotPingMessage)
+      log('mainFrameOriginTopHosts[current_active_tab_id]: ' + mainFrameOriginTopHosts[current_active_tab_id])
       browser.tabs.sendMessage(current_active_tab_id, {
-        "feedback": message.feedback,
-        "origin": mainFrameOriginTopHosts[current_active_tab_id]
-      });
+        'feedback': message.feedback,
+        'origin': mainFrameOriginTopHosts[current_active_tab_id]
+      })
     }
     if (message.hasOwnProperty('breakage')) {
       let testPilotPingMessage = {
@@ -221,25 +216,23 @@ function startListeners({blocklist, allowedHosts, entityList}) {
         trackerDomains: blocked_requests[current_active_tab_id],
         breakage: message.breakage,
         notes: message.notes
-      };
-      log("telemetry ping payload: " + JSON.stringify(testPilotPingMessage));
-      testpilotPingChannel.postMessage(testPilotPingMessage);
-      browser.tabs.sendMessage(current_active_tab_id, message);
+      }
+      log('telemetry ping payload: ' + JSON.stringify(testPilotPingMessage))
+      testpilotPingChannel.postMessage(testPilotPingMessage)
+      browser.tabs.sendMessage(current_active_tab_id, message)
     }
-    if (message == 'close-feedback') {
-      browser.tabs.sendMessage(current_active_tab_id, message);
+    if (message === 'close-feedback') {
+      browser.tabs.sendMessage(current_active_tab_id, message)
     }
-  });
-
+  })
 }
-
 
 const state = {
   blocklist: {},
   allowedHosts: [],
   entityList: {}
-};
+}
 
 loadLists(state).then(() => {
-  startListeners(state);
-}, console.error.bind(console));
+  startListeners(state)
+}, console.error.bind(console))

--- a/js/canonicalize.js
+++ b/js/canonicalize.js
@@ -1,60 +1,56 @@
-var ip4DecimalPattern = '^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$';
-var ip4HexPattern = '^(?:(?:0x[0-9a-f]{1,2})\.){3}(?:0x[0-9a-f]{1,2})$';
-var ip4OctalPattern = '^(?:(?:03[1-7][0-7]|0[12][0-7]{1,2}|[0-7]{1,2})\.){3}(?:03[1-7][0-7]|0[12][0-7]{1,2}|[0-7]{1,2})$';
-
+var ip4DecimalPattern = '^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?).){3}(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))$'
+var ip4HexPattern = '^(?:(?:0x[0-9a-f]{1,2}).){3}(?:0x[0-9a-f]{1,2})$'
+var ip4OctalPattern = '^(?:(?:03[1-7][0-7]|0[12][0-7]{1,2}|[0-7]{1,2}).){3}(?:03[1-7][0-7]|0[12][0-7]{1,2}|[0-7]{1,2})$'
 
 // like trim() helper from underscore.string:
 // trims chars from beginning and end of str
-function trim(str, chars) {
+function trim (str, chars) {
   // escape any regexp chars
-  chars = chars.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1');
-  return str.replace(new RegExp('^' + chars + '+|' + chars + '+$', 'g'), '');
+  chars = chars.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1')
+  return str.replace(new RegExp('^' + chars + '+|' + chars + '+$', 'g'), '')
 }
 
-
 // https://developers.google.com/safe-browsing/v4/urls-hashing#canonicalization
-function canonicalizeHost(host) {
+function canonicalizeHost (host) {
   // Remove all leading and trailing dots
-  var canonicalizedHost = trim(host, '.');
+  var canonicalizedHost = trim(host, '.')
 
   // Replace consecutive dots with a single dot
-  canonicalizedHost = canonicalizedHost.replace(new RegExp('[\.]+', 'g'), '.');
+  canonicalizedHost = canonicalizedHost.replace(new RegExp('[.]+', 'g'), '.')
 
   // If the hostname can be parsed as an IP address,
   // normalize it to 4 dot-separated decimal values.
   // The client should handle any legal IP-address encoding,
   // including octal, hex, and TODO: fewer than four components
-  var base = 10;
-  var isIP4Decimal, isIP4Hex, isIP4Octal;
+  var base = 10
+  var isIP4Decimal, isIP4Hex, isIP4Octal
 
-  isIP4Decimal = canonicalizedHost.match(ip4DecimalPattern) != null;
-  isIP4Hex = canonicalizedHost.match(ip4HexPattern) != null;
-  isIP4Octal = canonicalizedHost.match(ip4OctalPattern) != null;
+  isIP4Decimal = canonicalizedHost.match(ip4DecimalPattern) != null
+  isIP4Hex = canonicalizedHost.match(ip4HexPattern) != null
+  isIP4Octal = canonicalizedHost.match(ip4OctalPattern) != null
   if (isIP4Hex || isIP4Octal) {
     if (isIP4Hex) {
-      base = 16;
+      base = 16
     } else if (isIP4Octal) {
-      base = 8;
+      base = 8
     }
-    canonicalizedHost = canonicalizedHost.split('.').map(num => parseInt(num, base)).join('.');
+    canonicalizedHost = canonicalizedHost.split('.').map(num => parseInt(num, base)).join('.')
   }
 
   // Lowercase the whole string
-  canonicalizedHost = canonicalizedHost.toLowerCase();
-  return canonicalizedHost;
+  canonicalizedHost = canonicalizedHost.toLowerCase()
+  return canonicalizedHost
 }
 
-
-function allHosts(host) {
-  const allHosts = [];
-  const hostParts = host.split('.');
+function allHosts (host) {
+  const allHosts = []
+  const hostParts = host.split('.')
   while (hostParts.length > 1) {
-    allHosts.push(hostParts.join('.'));
-    hostParts.splice(0, 1);
+    allHosts.push(hostParts.join('.'))
+    hostParts.splice(0, 1)
   }
-  return allHosts;
+  return allHosts
 }
-
 
 module.exports = {
   allHosts,

--- a/js/contentscript.js
+++ b/js/contentscript.js
@@ -1,48 +1,49 @@
-var toolbarFrame, feedbackModalOverlay;
+var feedbackModalOverlay
+var toolbarFrame
 
-toolbarFrame = document.getElementById('blok-toolbar-iframe');
-feedbackModalOverlay = document.getElementById('blok-feedback-modal-overlay');
+toolbarFrame = document.getElementById('blok-toolbar-iframe')
+feedbackModalOverlay = document.getElementById('blok-feedback-modal-overlay')
 
 browser.runtime.onMessage.addListener(function (message) {
   // Any message indicates Blok has something to show
   if (!toolbarFrame) {
-    var toolbarSpacer = document.createElement("div");
-    toolbarSpacer.setAttribute("id", "blok-toolbar-spacer");
-    toolbarSpacer.setAttribute("class", "blok-toolbar-spacer");
-    var bodyEl = document.getElementsByTagName("body")[0];
-    bodyEl.insertBefore(toolbarSpacer, bodyEl.firstChild);
+    var toolbarSpacer = document.createElement('div')
+    toolbarSpacer.setAttribute('id', 'blok-toolbar-spacer')
+    toolbarSpacer.setAttribute('class', 'blok-toolbar-spacer')
+    var bodyEl = document.getElementsByTagName('body')[0]
+    bodyEl.insertBefore(toolbarSpacer, bodyEl.firstChild)
 
-    toolbarFrame = document.createElement("iframe");
-    toolbarFrame.setAttribute("id", "blok-toolbar-iframe");
-    toolbarFrame.setAttribute("class", "blok-toolbar-iframe");
-    toolbarFrame.setAttribute("src", browser.runtime.getURL('toolbar.html'));
-    document.body.appendChild(toolbarFrame);
+    toolbarFrame = document.createElement('iframe')
+    toolbarFrame.setAttribute('id', 'blok-toolbar-iframe')
+    toolbarFrame.setAttribute('class', 'blok-toolbar-iframe')
+    toolbarFrame.setAttribute('src', browser.runtime.getURL('toolbar.html'))
+    document.body.appendChild(toolbarFrame)
   }
 
   if (!feedbackModalOverlay) {
-    feedbackModalOverlay = document.createElement("div");
-    feedbackModalOverlay.setAttribute("class", "blok-feedback-modal-overlay blok-hide");
+    feedbackModalOverlay = document.createElement('div')
+    feedbackModalOverlay.setAttribute('class', 'blok-feedback-modal-overlay blok-hide')
 
-    let feedbackFrame = document.createElement("iframe");
-    feedbackFrame.setAttribute("id", "blok-feedback-iframe");
-    feedbackFrame.setAttribute("class", "blok-feedback-iframe");
-    feedbackFrame.setAttribute("src", browser.runtime.getURL('feedback.html'));
+    let feedbackFrame = document.createElement('iframe')
+    feedbackFrame.setAttribute('id', 'blok-feedback-iframe')
+    feedbackFrame.setAttribute('class', 'blok-feedback-iframe')
+    feedbackFrame.setAttribute('src', browser.runtime.getURL('feedback.html'))
 
-    feedbackModalOverlay.appendChild(feedbackFrame);
-    document.body.appendChild(feedbackModalOverlay);
+    feedbackModalOverlay.appendChild(feedbackFrame)
+    document.body.appendChild(feedbackModalOverlay)
   }
 
   // page-problem message should show modal for feedback
-  if (message.feedback && message.feedback == "page-problem") {
-    feedbackModalOverlay.setAttribute("class", "blok-feedback-modal-overlay");
-    document.body.appendChild(feedbackModalOverlay);
-    console.log("message.origin: " + message.origin);
-    feedbackModalOverlay.querySelector('#blok-feedback-iframe').contentDocument.querySelector('#feedback-title-site-name').textContent = message.origin;
-  } else if (message.feedback && message.feedback == "page-works") {
+  if (message.feedback && message.feedback === 'page-problem') {
+    feedbackModalOverlay.setAttribute('class', 'blok-feedback-modal-overlay')
+    document.body.appendChild(feedbackModalOverlay)
+    console.log('message.origin: ' + message.origin)
+    feedbackModalOverlay.querySelector('#blok-feedback-iframe').contentDocument.querySelector('#feedback-title-site-name').textContent = message.origin
+  } else if (message.feedback && message.feedback === 'page-works') {
     feedbackModalOverlay.remove()
   }
 
-  if (message == "close-feedback") {
+  if (message === 'close-feedback') {
     feedbackModalOverlay.remove()
   }
-});
+})

--- a/js/feedback.js
+++ b/js/feedback.js
@@ -1,14 +1,14 @@
 for (let closeBtn of document.querySelectorAll('.close-feedback')) {
   closeBtn.addEventListener('click', function () {
-    browser.runtime.sendMessage('close-feedback');
-  });
+    browser.runtime.sendMessage('close-feedback')
+  })
 }
 
-document.querySelector('.submit').addEventListener('click', function() {
+document.querySelector('.submit').addEventListener('click', function () {
   let message = {
     'breakage': document.querySelector('input:checked').value,
     'notes': document.querySelector('textarea#notes').textContent
-  };
-  browser.runtime.sendMessage(message);
-  browser.runtime.sendMessage('close-feedback');
-});
+  }
+  browser.runtime.sendMessage(message)
+  browser.runtime.sendMessage('close-feedback')
+})

--- a/js/lists.js
+++ b/js/lists.js
@@ -1,33 +1,31 @@
-function loadLists(state) {
+function loadLists (state) {
   const blockListPromise = loadJSON('disconnect-blocklist.json').then((data) => {
-    state.blocklist = processBlockListJSON(data);
-  });
+    state.blocklist = processBlockListJSON(data)
+  })
 
   const entityListPromise = loadJSON('disconnect-entitylist.json').then((data) => {
-    state.entityList = data;
-  });
+    state.entityList = data
+  })
 
   const allowedHostsPromise = getAllowedHostsList().then((allowedHosts) => {
-    state.allowedHosts = allowedHosts;
-  });
+    state.allowedHosts = allowedHosts
+  })
 
-  return Promise.all([blockListPromise, entityListPromise, allowedHostsPromise]);
+  return Promise.all([blockListPromise, entityListPromise, allowedHostsPromise])
 }
 
-
-function loadJSON(url) {
+function loadJSON (url) {
   return fetch(url)
-    .then((res) => res.json());
+    .then((res) => res.json())
 }
 
-
-function processBlockListJSON(data) {
-  const blocklist = {};
+function processBlockListJSON (data) {
+  const blocklist = {}
 
   // remove un-needed categories per disconnect
-  delete data.categories['Content'];
-  delete data.categories['Legacy Disconnect'];
-  delete data.categories['Legacy Content'];
+  delete data.categories['Content']
+  delete data.categories['Legacy Disconnect']
+  delete data.categories['Legacy Content']
 
   // parse thru the disconnect blocklist and create
   // local blocklist "grouped" by main domain. I.e.,
@@ -36,42 +34,40 @@ function processBlockListJSON(data) {
   // blocklist["doubleclick.net"] = http://www.google.com
   // blocklist["google-analytics.com"] = http://www.google.com
   // etc.
-  for (category_name in data.categories) {
-    var category = data.categories[category_name];
-    var entity_count = category.length;
+  for (const category_name in data.categories) {
+    var category = data.categories[category_name]
+    var entity_count = category.length
 
     for (var i = 0; i < entity_count; i++) {
-      var entity = category[i];
+      var entity = category[i]
 
-      for (entity_name in entity) {
-        var urls = entity[entity_name];
+      for (const entity_name in entity) {
+        var urls = entity[entity_name]
 
-        for (main_domain in urls) {
-          blocklist[main_domain] = [];
-          var domains = urls[main_domain];
-          var domains_count = domains.length;
+        for (const main_domain in urls) {
+          blocklist[main_domain] = []
+          var domains = urls[main_domain]
+          var domains_count = domains.length
 
           for (var j = 0; j < domains_count; j++) {
-            blocklist[domains[j]] = main_domain;
+            blocklist[domains[j]] = main_domain
           }
         }
       }
     }
   }
 
-  return blocklist;
+  return blocklist
 }
 
-
-function getAllowedHostsList() {
-  return browser.storage.local.get("allowedHosts").then((item) => {
+function getAllowedHostsList () {
+  return browser.storage.local.get('allowedHosts').then((item) => {
     if (item.allowedHosts) {
-      return item.allowedHosts;
+      return item.allowedHosts
     }
-    return [];
-  });
+    return []
+  })
 }
-
 
 module.exports = {
   loadLists

--- a/js/log.js
+++ b/js/log.js
@@ -1,5 +1,5 @@
-if (process.env.MODE === "production") {
-  exports.log = function noop(){};
+if (process.env.MODE === 'production') {
+  exports.log = function noop () {}
 } else {
-  exports.log = console.log.bind(console);
+  exports.log = console.log.bind(console)
 }

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -1,42 +1,42 @@
 browser.runtime.onMessage.addListener(function (runtimeMessage) {
-  var blockedEntitiesCount, allowedEntitiesCount;
+  var blockedEntitiesCount, allowedEntitiesCount
   if (runtimeMessage.hasOwnProperty('origin-disabled')) {
-    allowedEntitiesCount = runtimeMessage.allowed_entities.length;
+    allowedEntitiesCount = runtimeMessage.allowed_entities.length
 
-    document.querySelector('#title-blocking').className = 'hide';
-    document.querySelector('#title-disabled').className = 'title';
-    document.querySelector('#title-allowed-count').innerHTML = allowedEntitiesCount;
+    document.querySelector('#title-blocking').className = 'hide'
+    document.querySelector('#title-disabled').className = 'title'
+    document.querySelector('#title-allowed-count').innerHTML = allowedEntitiesCount
 
     for (let feedbackElement of document.querySelectorAll('.feedback')) {
-      feedbackElement.className = 'feedback hide';
+      feedbackElement.className = 'feedback hide'
     }
 
     if (runtimeMessage.hasOwnProperty('reason-given') && runtimeMessage['reason-given'] != null) {
-      document.querySelector('#disable-reason-thankyou').className = '';
+      document.querySelector('#disable-reason-thankyou').className = ''
     } else {
-      document.querySelector('#disable-reasons').className = '';
+      document.querySelector('#disable-reasons').className = ''
     }
   } else {
-    blockedEntitiesCount = runtimeMessage.blocked_entities.length;
-    document.querySelector('#title-block-count').innerHTML = blockedEntitiesCount;
+    blockedEntitiesCount = runtimeMessage.blocked_entities.length
+    document.querySelector('#title-block-count').innerHTML = blockedEntitiesCount
   }
-});
+})
 
 document.querySelector('#disable-link').addEventListener('click', function () {
-  browser.runtime.sendMessage("disable");
-});
+  browser.runtime.sendMessage('disable')
+})
 
 document.querySelector('#re-enable-link').addEventListener('click', function () {
-  browser.runtime.sendMessage("re-enable");
-});
+  browser.runtime.sendMessage('re-enable')
+})
 
 for (let feedbackBtn of document.querySelectorAll('.feedback-btn')) {
   feedbackBtn.addEventListener('click', function (event) {
-    var feedback = event.target.dataset.feedback;
-    browser.runtime.sendMessage({"feedback": feedback});
+    var feedback = event.target.dataset.feedback
+    browser.runtime.sendMessage({'feedback': feedback})
     for (let feedbackDiv of document.querySelectorAll('.feedback')) {
-      feedbackDiv.className = 'hide';
+      feedbackDiv.className = 'hide'
     }
-    document.querySelector('#feedback-' + feedback).className = 'feedback';
-  });
+    document.querySelector('#feedback-' + feedback).className = 'feedback'
+  })
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build-dev": "npm test && MODE=dev npm run bundle && web-ext build",
     "coverage": "nyc npm test",
     "firefox": "npm run bundle && web-ext run",
+    "lint": "standard",
     "test": "tape tests/**/*.js | faucet",
     "watch": "npm-watch"
   },
@@ -37,7 +38,16 @@
     "faucet": "0.0.1",
     "npm-watch": "0.1.5",
     "nyc": "7.0.0",
+    "standard": "7.1.2",
     "tape": "4.6.0"
+  },
+  "standard": {
+    "globals": [
+      "BroadcastChannel",
+      "browser",
+      "fetch",
+      "URL"
+    ]
   },
   "watch": {
     "bundle": {

--- a/tests/hostname-canonicalization.js
+++ b/tests/hostname-canonicalization.js
@@ -1,53 +1,53 @@
-var test = require('tape');
-var {allHosts, canonicalizeHost} = require('../js/canonicalize');
+var test = require('tape')
+var {allHosts, canonicalizeHost} = require('../js/canonicalize')
 
-test('canonicalizeHost plain host is plain', function(t) {
-  t.plan(1);
-  t.equal(canonicalizeHost('trackertest.org'), 'trackertest.org');
-});
+test('canonicalizeHost plain host is plain', function (t) {
+  t.plan(1)
+  t.equal(canonicalizeHost('trackertest.org'), 'trackertest.org')
+})
 
-test('canonicalizeHost leading and trailing dots are trimmed', function(t) {
-  t.plan(3);
-  t.equal(canonicalizeHost('.trackertest.org'), 'trackertest.org');
-  t.equal(canonicalizeHost('trackertest.org.'), 'trackertest.org');
-  t.equal(canonicalizeHost('.trackertest.org.'), 'trackertest.org');
-});
+test('canonicalizeHost leading and trailing dots are trimmed', function (t) {
+  t.plan(3)
+  t.equal(canonicalizeHost('.trackertest.org'), 'trackertest.org')
+  t.equal(canonicalizeHost('trackertest.org.'), 'trackertest.org')
+  t.equal(canonicalizeHost('.trackertest.org.'), 'trackertest.org')
+})
 
-test('canonicalizeHost consecutive dots are consolidated', function(t) {
-  t.plan(2);
-  t.equal(canonicalizeHost('trackertest..org'), 'trackertest.org');
-  t.equal(canonicalizeHost('track..trackertest..org'), 'track.trackertest.org');
-});
+test('canonicalizeHost consecutive dots are consolidated', function (t) {
+  t.plan(2)
+  t.equal(canonicalizeHost('trackertest..org'), 'trackertest.org')
+  t.equal(canonicalizeHost('track..trackertest..org'), 'track.trackertest.org')
+})
 
-test('canonicalizeHost ip4 addresses decimal, hex, and octal', function(t) {
+test('canonicalizeHost ip4 addresses decimal, hex, and octal', function (t) {
   // OpenDNS as test addresses
-  t.plan(3);
+  t.plan(3)
   // plain decimal
-  t.equal(canonicalizeHost('208.67.222.222'), '208.67.222.222');
+  t.equal(canonicalizeHost('208.67.222.222'), '208.67.222.222')
   // hex
-  t.equal(canonicalizeHost('0xd0.0x43.0xde.0xde'), '208.67.222.222');
+  t.equal(canonicalizeHost('0xd0.0x43.0xde.0xde'), '208.67.222.222')
   // octal
-  t.equal(canonicalizeHost('0320.0103.0336.0336'), '208.67.222.222');
-});
+  t.equal(canonicalizeHost('0320.0103.0336.0336'), '208.67.222.222')
+})
 
-test('canonicalizeHost lowercase everything', function(t) {
-  t.plan(2);
-  t.equal(canonicalizeHost('TrackerTest.Org'), 'trackertest.org');
-  t.equal(canonicalizeHost('TRACKERTEST.ORG'), 'trackertest.org');
-});
+test('canonicalizeHost lowercase everything', function (t) {
+  t.plan(2)
+  t.equal(canonicalizeHost('TrackerTest.Org'), 'trackertest.org')
+  t.equal(canonicalizeHost('TRACKERTEST.ORG'), 'trackertest.org')
+})
 
-test('canonicalizeHost test everything together', function(t) {
-  t.plan(1);
-  t.equal(canonicalizeHost('..TRACK..TrackerTest.Org.'), 'track.trackertest.org');
-});
+test('canonicalizeHost test everything together', function (t) {
+  t.plan(1)
+  t.equal(canonicalizeHost('..TRACK..TrackerTest.Org.'), 'track.trackertest.org')
+})
 
-test('allHosts returns single element for trackertest.org', function(t) {
-  t.plan(1);
-  t.deepEqual(allHosts('trackertest.org'), ['trackertest.org']);
-});
+test('allHosts returns single element for trackertest.org', function (t) {
+  t.plan(1)
+  t.deepEqual(allHosts('trackertest.org'), ['trackertest.org'])
+})
 
-test('allHosts returns multiple elements for tracky.track.trackertest.org', function(t) {
-  t.plan(1);
+test('allHosts returns multiple elements for tracky.track.trackertest.org', function (t) {
+  t.plan(1)
   t.deepEqual(
     allHosts('tracky.track.trackertest.org'),
     [
@@ -55,5 +55,5 @@ test('allHosts returns multiple elements for tracky.track.trackertest.org', func
       'track.trackertest.org',
       'trackertest.org'
     ]
-  );
-});
+  )
+})


### PR DESCRIPTION
I ran this through [**standard-format**](http://npm.im/standard-format), which auto-formatted everything, which is why there was oodles of churn with single-vs-double quotes, and removal of semicolons.