### PR TITLE
fix #150: remove ALL matching allowedHosts items

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -248,7 +248,15 @@ function startMessageListener (allowedHosts, reportedHosts, testPilotPingChannel
         tabId: currentActiveTabID,
         path: 'img/tracking-protection-16.png'
       })
-      allowedHosts.splice(mainFrameOriginDisabledIndex, 1)
+
+      // If there are multiple allowedHosts entries for minFrameOriginTopHost somehow,
+      // splice them all out; https://github.com/mozilla/blok/issues/150
+      let lastMainFrameOriginDisabledIndex = allowedHosts.lastIndexOf(mainFrameOriginTopHost)
+      do {
+        mainFrameOriginDisabledIndex = allowedHosts.indexOf(mainFrameOriginTopHost)
+        allowedHosts.splice(mainFrameOriginDisabledIndex, 1)
+        lastMainFrameOriginDisabledIndex = allowedHosts.lastIndexOf(mainFrameOriginTopHost)
+      } while (mainFrameOriginDisabledIndex !== lastMainFrameOriginDisabledIndex)
       browser.storage.local.set({allowedHosts: allowedHosts})
       browser.tabs.reload(currentActiveTabID)
     }


### PR DESCRIPTION
I couldn't actually reproduce the original state of #150. I.e., I think it was caused by a previous bug in the add-on that added multiple items of the same host into the `allowedHosts` array. That bug has since been closed, but those of us (like @pdehaan) who had the add-on running before it was closed likely got into a state where we had multiple items of the same host in our `allowedHosts` array.

To fix, I wrapped the `allowedHosts.splice` call in a `do...while` loop to clear out **ALL** matching items from the `allowedHosts` array.

To test:

1. Run the add-on and disable protection for a few different sites.
2. Go back to at least one of the sites where you disabled protection, and re-enable it.

Verify:

Refresh each of the sites and verify that their protection state is what you expect. I.e., the disabled sites are still disabled, and the re-enabled site(s) is enabled.