### PR TITLE
fix #147: use table-cell to fix linux display

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -105,6 +105,7 @@ input:checked ~ .switch-paddle {
   border-radius: 3px;
   border: 1px solid #ccc;
   box-sizing: border-box;
+  display: table-cell;
   padding: 5px 10px;
   width: 100%;
 }


### PR DESCRIPTION
Using `display: table-cell` fixes the `radio-form` display for Linux, and preserves the display for others.